### PR TITLE
rpc-test: create block files for import synchronous

### DIFF
--- a/validators/ethereum/rpc-tests/makechain.js
+++ b/validators/ethereum/rpc-tests/makechain.js
@@ -7,9 +7,9 @@ var fs = require('fs');
 var test = require("/rpc-tests/lib/tests/BlockchainTests/bcRPC_API_Test.json");
 
 // Iterate over all the blocks and export them
-fs.mkdir("/blocks")
+fs.mkdirSync("/blocks")
 
 var blocks = test.RPC_API_Test.blocks;
 for (var i = 0; i < blocks.length; i++) {
-	fs.writeFile("/blocks/" + i, new Buffer(blocks[i].rlp.substring(2), "hex"));
+	fs.writeFileSync("/blocks/" + i, new Buffer(blocks[i].rlp.substring(2), "hex"));
 }


### PR DESCRIPTION
Currently the `makechain.js` create block files for the rpc-tests in an asynchronous matter. This has several problems:
1. the blocks directory might not been created, and writing block files into that directory can fail
2. the nodejs script can exit while not all files have been written since no callback is given for the `writeFile` method

This PR will do everything synchronously. This ensures all block files are written before the nodejs script exits.