### PR TITLE
hive: add support for custom keystore location

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The behavioral configuration variables:
   * `HIVE_FORK_HOMESTEAD` the block number of the Ethereum Homestead transition
   * `HIVE_FORK_DAO_BLOCK` the block number of the DAO hard-fork transition
   * `HIVE_FORK_DAO_VOTE` whether the node supports or opposes the DAO hard-fork
+  * `HIVE_KEYSTORE` custom keystore directory for node
   * `HIVE_MINER` address to credit with mining rewards (if set, start mining)
   * `HIVE_MINER_EXTRA` extra-data field to set for newly minted blocks
 

--- a/clients/go-ethereum:develop/geth.sh
+++ b/clients/go-ethereum:develop/geth.sh
@@ -14,6 +14,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_KEYSTORE       location for the keystore
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -38,6 +39,11 @@ if [ "$HIVE_NODETYPE" == "full" ]; then
 fi
 if [ "$HIVE_NODETYPE" == "light" ]; then
 	FLAGS="$FLAGS --light"
+fi
+
+# Handle keystore location
+if [ "$HIVE_KEYSTORE" != "" ]; then
+    FLAGS="$FLAGS --keystore $HIVE_KEYSTORE"
 fi
 
 # Override any chain configs in the go-ethereum specific way

--- a/clients/go-ethereum:local/geth.sh
+++ b/clients/go-ethereum:local/geth.sh
@@ -14,6 +14,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_KEYSTORE       location for the keystore
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -38,6 +39,11 @@ if [ "$HIVE_NODETYPE" == "full" ]; then
 fi
 if [ "$HIVE_NODETYPE" == "light" ]; then
 	FLAGS="$FLAGS --light"
+fi
+
+# Handle keystore location
+if [ "$HIVE_KEYSTORE" != "" ]; then
+    FLAGS="$FLAGS --keystore $HIVE_KEYSTORE"
 fi
 
 # Override any chain configs in the go-ethereum specific way

--- a/clients/go-ethereum:master/geth.sh
+++ b/clients/go-ethereum:master/geth.sh
@@ -14,6 +14,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_KEYSTORE       location for the keystore
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -38,6 +39,11 @@ if [ "$HIVE_NODETYPE" == "full" ]; then
 fi
 if [ "$HIVE_NODETYPE" == "light" ]; then
 	FLAGS="$FLAGS --light"
+fi
+
+# Handle keystore location
+if [ "$HIVE_KEYSTORE" != "" ]; then
+    FLAGS="$FLAGS --keystore $HIVE_KEYSTORE"
 fi
 
 # Override any chain configs in the go-ethereum specific way

--- a/containers.go
+++ b/containers.go
@@ -147,6 +147,10 @@ func createClientContainer(daemon *docker.Client, client string, tester string, 
 	if err = copyBetweenContainers(daemon, c.ID, t.ID, "/blocks"); err != nil {
 		return nil, err
 	}
+	if err = copyBetweenContainers(daemon, c.ID, t.ID, "/keystore"); err != nil {
+		return nil, err
+	}
+
 	// Inject any explicit file overrides into the client container
 	if err := uploadToContainer(daemon, c.ID, overrideFiles); err != nil {
 		daemon.RemoveContainer(docker.RemoveContainerOptions{ID: c.ID, Force: true})


### PR DESCRIPTION
This PR adds support for custom keystore directories for nodes.

I would like to start multiple nodes with their own set of keys that have preallocated amounts of ether in the genesis block. This PR will copy all subdirectories/files from `/keystore` into the node container. It also introduces a new variable that can be used to specify a custom keystore.

Example usage:
Create the keystore directories in the docker file:
```
RUN mkdir -p /keystore/1 /keystore/2 /keystore/3 /keystore/4
ADD 87da6a8c6e9eff15d703fc2773e32f6af8dbe301 /keystore/1/
ADD 0161e041aad467a890839d5b08b138c1e6373072 /keystore/2/
ADD b97de4b8c857e4f6bc354f226dc3249aaee49209 /keystore/3/
ADD cf49fda3be353c69b41ed96333cd24302da4556f /keystore/4/
```

Start the nodes in the simulator script with a custom keystore directory:
```
for i in `seq 1 $N_RPC_NODES`; do
	echo "Starting geth node #$i..."
	etherbase=$(ls /keystore/$i | sort -n | head -1)
	nodes+=(`curl -sf -X POST --data "HIVE_KEYSTORE=/keystore/$i" --data "HIVE_MINER=$etherbase" --data-urlencode "HIVE_BOOTNODE=$BOOTNODE_ENODE" $HIVE_SIMULATOR/nodes`)
done
```
