### PR TITLE
Refactored the Dockerfiles

### DIFF
--- a/clients/go-ethereum:develop/Dockerfile
+++ b/clients/go-ethereum:develop/Dockerfile
@@ -5,17 +5,20 @@
 # needing to constantly rebuild.
 FROM alpine:3.4
 
-# Build go-ethereum on the fly and delete all build tools afterwards
-RUN \
-  apk add --update go git make gcc musl-dev                                    && \
-  git clone --depth 1 --branch develop https://github.com/ethereum/go-ethereum && \
-  (cd go-ethereum && make geth)                                                && \
-  cp go-ethereum/build/bin/geth /geth                                          && \
-  apk del go git make gcc musl-dev                                             && \
-  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
-
 # Make sure bash and jq is available for easier wrapper implementation
 RUN apk add --update bash jq
+
+# Build tools
+RUN apk add --update go git make gcc musl-dev
+
+# Build go-ethereum on the fly and delete all build tools afterwards
+RUN git clone https://github.com/ethereum/go-ethereum
+
+RUN \
+  (cd go-ethereum && git checkout develop && make geth)     && \
+  cp go-ethereum/build/bin/geth /geth                 && \
+  apk del go git make gcc musl-dev                    && \
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 # Inject the startup script
 ADD geth.sh /geth.sh

--- a/clients/go-ethereum:master/Dockerfile
+++ b/clients/go-ethereum:master/Dockerfile
@@ -5,17 +5,20 @@
 # needing to constantly rebuild.
 FROM alpine:3.4
 
+# Make sure bash and jq is available for easier wrapper implementation
+RUN apk add --update bash jq
+
+# Build tools
+RUN apk add --update go git make gcc musl-dev
+
 # Build go-ethereum on the fly and delete all build tools afterwards
+RUN git clone https://github.com/ethereum/go-ethereum
+
 RUN \
-  apk add --update go git make gcc musl-dev                   && \
-  git clone --depth 1 https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth)                               && \
   cp go-ethereum/build/bin/geth /geth                         && \
   apk del go git make gcc musl-dev                            && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
-
-# Make sure bash and jq is available for easier wrapper implementation
-RUN apk add --update bash jq
 
 # Inject the startup script
 ADD geth.sh /geth.sh

--- a/clients/parity:beta/Dockerfile
+++ b/clients/parity:beta/Dockerfile
@@ -1,23 +1,16 @@
 # Docker container spec for building the master branch of parity.
 FROM ubuntu:16.04
 
-# Build parity on the fly and delete all build tools afterwards
-RUN \
-  # Install parity from sources
-  apt-get -y update                                             && \
-  apt-get install -y curl git make g++ gcc file binutils        && \
-  curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo && \
-	\
-  git clone --depth 1 --branch beta https://github.com/ethcore/parity && \
-	cd parity && cargo build --release                                  && \
-	strip /parity/target/release/parity                                 && \
-	\
-	cd / && cp /parity/target/release/parity /parity.bin && \
-	rm -rf parity && mv /parity.bin /parity              && \
-  \
-  sh rustup.sh --uninstall --disable-sudo               && \
-  apt-get remove -y curl git make g++ gcc file binutils && \
-  rm -rf /root/.cargo
+RUN apt-get -y update
+
+# Make sure bash and jq is available for easier wrapper implementation
+RUN apt-get install -y bash jq bc
+
+# Rust and Parity deps
+RUN apt-get install -y curl git make g++ gcc file binutils
+RUN curl -OsSf https://static.rust-lang.org/rustup.sh && \
+  sh rustup.sh --disable-sudo
+
 
 # Inject ethminer to support mining
 RUN \
@@ -25,8 +18,22 @@ RUN \
   add-apt-repository ppa:ethereum/ethereum      && \
   apt-get -y update && apt-get install -y ethminer
 
-# Make sure bash and jq is available for easier wrapper implementation
-RUN apt-get install -y bash jq bc
+# Fetch parity and dependencies
+RUN git clone https://github.com/ethcore/parity && \
+  cd parity && cargo fetch 
+
+# Build parity on the fly and delete all build tools afterwards
+RUN \
+  cd parity && git checkout beta && cargo build --release
+  strip /parity/target/release/parity                                 && \
+  \
+  cd / && cp /parity/target/release/parity /parity.bin && \
+  rm -rf parity && mv /parity.bin /parity
+
+RUN sh rustup.sh --uninstall --disable-sudo               && \
+  apt-get remove -y curl git make g++ gcc file binutils && \
+  rm -rf /root/.cargo
+
 
 # Inject the startup script and associated resources
 ADD parity.sh /parity.sh

--- a/clients/parity:beta/Dockerfile
+++ b/clients/parity:beta/Dockerfile
@@ -24,14 +24,14 @@ RUN git clone https://github.com/ethcore/parity && \
 
 # Build parity on the fly and delete all build tools afterwards
 RUN \
-  cd parity && git checkout beta && cargo build --release
-  strip /parity/target/release/parity                                 && \
+  cd parity && git checkout beta && cargo build --release && \
+  strip /parity/target/release/parity                     && \
   \
-  cd / && cp /parity/target/release/parity /parity.bin && \
+  cd / && cp /parity/target/release/parity /parity.bin    && \
   rm -rf parity && mv /parity.bin /parity
 
 RUN sh rustup.sh --uninstall --disable-sudo               && \
-  apt-get remove -y curl git make g++ gcc file binutils && \
+  apt-get remove -y curl git make g++ gcc file binutils   && \
   rm -rf /root/.cargo
 
 

--- a/clients/parity:master/Dockerfile
+++ b/clients/parity:master/Dockerfile
@@ -1,23 +1,16 @@
 # Docker container spec for building the master branch of parity.
 FROM ubuntu:16.04
 
-# Build parity on the fly and delete all build tools afterwards
-RUN \
-  # Install parity from sources
-  apt-get -y update                                             && \
-  apt-get install -y curl git make g++ gcc file binutils        && \
-  curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo && \
-	\
-  git clone --depth 1 https://github.com/ethcore/parity && \
-	cd parity && cargo build --release                    && \
-	strip /parity/target/release/parity                   && \
-	\
-	cd / && cp /parity/target/release/parity /parity.bin && \
-	rm -rf parity && mv /parity.bin /parity              && \
-  \
-  sh rustup.sh --uninstall --disable-sudo               && \
-  apt-get remove -y curl git make g++ gcc file binutils && \
-  rm -rf /root/.cargo
+RUN apt-get -y update
+
+# Make sure bash and jq is available for easier wrapper implementation
+RUN apt-get install -y bash jq bc
+
+# Rust and Parity deps
+RUN apt-get install -y curl git make g++ gcc file binutils
+RUN curl -OsSf https://static.rust-lang.org/rustup.sh && \
+  sh rustup.sh --disable-sudo
+
 
 # Inject ethminer to support mining
 RUN \
@@ -25,8 +18,22 @@ RUN \
   add-apt-repository ppa:ethereum/ethereum      && \
   apt-get -y update && apt-get install -y ethminer
 
-# Make sure bash and jq is available for easier wrapper implementation
-RUN apt-get install -y bash jq bc
+# Fetch parity and dependencies
+RUN git clone https://github.com/ethcore/parity && \
+  cd parity && cargo fetch 
+
+# Build parity on the fly and delete all build tools afterwards
+RUN \
+  cd parity && cargo build --release
+  strip /parity/target/release/parity                                 && \
+  \
+  cd / && cp /parity/target/release/parity /parity.bin && \
+  rm -rf parity && mv /parity.bin /parity
+
+RUN sh rustup.sh --uninstall --disable-sudo               && \
+  apt-get remove -y curl git make g++ gcc file binutils && \
+  rm -rf /root/.cargo
+
 
 # Inject the startup script and associated resources
 ADD parity.sh /parity.sh

--- a/clients/parity:master/Dockerfile
+++ b/clients/parity:master/Dockerfile
@@ -24,13 +24,13 @@ RUN git clone https://github.com/ethcore/parity && \
 
 # Build parity on the fly and delete all build tools afterwards
 RUN \
-  cd parity && cargo build --release
-  strip /parity/target/release/parity                                 && \
+  cd parity && cargo build --release                    && \
+  strip /parity/target/release/parity                   && \
   \
-  cd / && cp /parity/target/release/parity /parity.bin && \
+  cd / && cp /parity/target/release/parity /parity.bin  && \
   rm -rf parity && mv /parity.bin /parity
 
-RUN sh rustup.sh --uninstall --disable-sudo               && \
+RUN sh rustup.sh --uninstall --disable-sudo             && \
   apt-get remove -y curl git make g++ gcc file binutils && \
   rm -rf /root/.cargo
 

--- a/clients/parity:stable/Dockerfile
+++ b/clients/parity:stable/Dockerfile
@@ -24,14 +24,14 @@ RUN git clone https://github.com/ethcore/parity && \
 
 # Build parity on the fly and delete all build tools afterwards
 RUN \
-  cd parity && git checkout stable && cargo build --release
-  strip /parity/target/release/parity                                 && \
+  cd parity && git checkout stable && cargo build --release && \
+  strip /parity/target/release/parity                       && \
   \
-  cd / && cp /parity/target/release/parity /parity.bin && \
+  cd / && cp /parity/target/release/parity /parity.bin      && \
   rm -rf parity && mv /parity.bin /parity
 
-RUN sh rustup.sh --uninstall --disable-sudo               && \
-  apt-get remove -y curl git make g++ gcc file binutils && \
+RUN sh rustup.sh --uninstall --disable-sudo                 && \
+  apt-get remove -y curl git make g++ gcc file binutils     && \
   rm -rf /root/.cargo
 
 

--- a/clients/parity:stable/Dockerfile
+++ b/clients/parity:stable/Dockerfile
@@ -1,23 +1,16 @@
 # Docker container spec for building the master branch of parity.
 FROM ubuntu:16.04
 
-# Build parity on the fly and delete all build tools afterwards
-RUN \
-  # Install parity from sources
-  apt-get -y update                                             && \
-  apt-get install -y curl git make g++ gcc file binutils        && \
-  curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo && \
-	\
-  git clone --depth 1 --branch stable https://github.com/ethcore/parity && \
-	cd parity && cargo build --release                                    && \
-	strip /parity/target/release/parity                                   && \
-	\
-	cd / && cp /parity/target/release/parity /parity.bin && \
-	rm -rf parity && mv /parity.bin /parity              && \
-  \
-  sh rustup.sh --uninstall --disable-sudo               && \
-  apt-get remove -y curl git make g++ gcc file binutils && \
-  rm -rf /root/.cargo
+RUN apt-get -y update
+
+# Make sure bash and jq is available for easier wrapper implementation
+RUN apt-get install -y bash jq bc
+
+# Rust and Parity deps
+RUN apt-get install -y curl git make g++ gcc file binutils
+RUN curl -OsSf https://static.rust-lang.org/rustup.sh && \
+  sh rustup.sh --disable-sudo
+
 
 # Inject ethminer to support mining
 RUN \
@@ -25,8 +18,22 @@ RUN \
   add-apt-repository ppa:ethereum/ethereum      && \
   apt-get -y update && apt-get install -y ethminer
 
-# Make sure bash and jq is available for easier wrapper implementation
-RUN apt-get install -y bash jq bc
+# Fetch parity and dependencies
+RUN git clone https://github.com/ethcore/parity && \
+  cd parity && cargo fetch 
+
+# Build parity on the fly and delete all build tools afterwards
+RUN \
+  cd parity && git checkout stable && cargo build --release
+  strip /parity/target/release/parity                                 && \
+  \
+  cd / && cp /parity/target/release/parity /parity.bin && \
+  rm -rf parity && mv /parity.bin /parity
+
+RUN sh rustup.sh --uninstall --disable-sudo               && \
+  apt-get remove -y curl git make g++ gcc file binutils && \
+  rm -rf /root/.cargo
+
 
 # Inject the startup script and associated resources
 ADD parity.sh /parity.sh


### PR DESCRIPTION
This PR organises the Dockerfiles so that the docker cache is better reused between clients. Basically: 
- Fetch all general utilities and update package repositories 
- Check out the relevant github repo
- For parity: `cargo fetch` to download most of the dependencies

The steps above are cached by docker after the first client has been built. Afterwards, the remaining non-cached steps are
- Check out correct branch
- Build

This shaves a lot of times off the build times for the docker images
See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
