### PR TITLE
update parity flag --no-network to --nodiscover

### DIFF
--- a/clients/parity:beta/parity.sh
+++ b/clients/parity:beta/parity.sh
@@ -26,7 +26,7 @@ set -e
 if [ "$HIVE_BOOTNODE" != "" ]; then
 	FLAGS="$FLAGS --bootnodes $HIVE_BOOTNODE"
 else
-	FLAGS="$FLAGS --no-network"
+	FLAGS="$FLAGS --nodiscover"
 fi
 
 # Configure and set the chain definition for the node

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -26,7 +26,7 @@ set -e
 if [ "$HIVE_BOOTNODE" != "" ]; then
 	FLAGS="$FLAGS --bootnodes $HIVE_BOOTNODE"
 else
-	FLAGS="$FLAGS --no-network"
+	FLAGS="$FLAGS --nodiscover"
 fi
 
 # Configure and set the chain definition for the node

--- a/clients/parity:stable/parity.sh
+++ b/clients/parity:stable/parity.sh
@@ -26,7 +26,7 @@ set -e
 if [ "$HIVE_BOOTNODE" != "" ]; then
 	FLAGS="$FLAGS --bootnodes $HIVE_BOOTNODE"
 else
-	FLAGS="$FLAGS --no-network"
+	FLAGS="$FLAGS --nodiscover"
 fi
 
 # Configure and set the chain definition for the node


### PR DESCRIPTION
Parity [no longer](https://github.com/ethcore/parity/commit/744501c45460098be5ad41d9b7783c84fc92a0d4#diff-a446157098e33897a7686a206229874a) supports the --no-network flag.