### PR TITLE
fix parity homesteadTransition config

### DIFF
--- a/clients/parity:beta/parity.sh
+++ b/clients/parity:beta/parity.sh
@@ -64,7 +64,7 @@ if [ "$HIVE_TESTNET" == "1" ]; then
 fi
 if [ "$HIVE_FORK_HOMESTEAD" != "" ]; then
 	HEX_HIVE_FORK_HOMESTEAD=`echo "obase=16; $HIVE_FORK_HOMESTEAD" | bc`
-	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"homesteadTransition\"]; $HIVE_FORK_HOMESTEAD)"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"homesteadTransition\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
 fi
 

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -64,7 +64,7 @@ if [ "$HIVE_TESTNET" == "1" ]; then
 fi
 if [ "$HIVE_FORK_HOMESTEAD" != "" ]; then
 	HEX_HIVE_FORK_HOMESTEAD=`echo "obase=16; $HIVE_FORK_HOMESTEAD" | bc`
-	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"homesteadTransition\"]; $HEX_HIVE_FORK_HOMESTEAD)"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"homesteadTransition\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
 fi
 


### PR DESCRIPTION
For `parity:master/parity.sh` the jq command `setpath` fails if the hex string `HEX_HIVE_FORK_HOMESTEAD` is not in quotes ("118C30" should be in quotes):

```
[39a55b90] jq: error: syntax error, unexpected IDENT, expecting ';' or ')' (Unix shell quoting issues?) at <top-level>, line 1:
[39a55b90] setpath(["engine", "Ethash", "params", "homesteadTransition"]; 118C30)                                                                  
[39a55b90] jq: 1 compile error
```

And for `parity:beta/parity.sh` the `homesteadTransition` config should be in hex according to the [wiki example](https://github.com/ethcore/parity/wiki/Proof-of-Work-Chains).