### PR TITLE
Fix Parity, Geth-json, ignore invalid hex/rlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ The behavioral configuration variables:
     * The HF for repricing certain opcodes, EIP 150
   * `HIVE_FORK_SPURIOUS` the block number of the Ethereum Homestead transition
     * The HF for replay protection, state cleaning etc. EIPs 155,160,161. 
+  * `HIVE_FORK_METROPOLIS` the block number of the Metropolis hardfork
   * `HIVE_MINER` address to credit with mining rewards (if set, start mining)
   * `HIVE_MINER_EXTRA` extra-data field to set for newly minted blocks
+
 
 ### Starting the client
 

--- a/clients/go-ethereum:local/geth.sh
+++ b/clients/go-ethereum:local/geth.sh
@@ -17,7 +17,8 @@
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
 #  - HIVE_FORK_TANGERINE block number of TangerineWhistle
-#  - HIVE_FORK_SPURIOUS  block number of SpurioisDragon
+#  - HIVE_FORK_SPURIOUS  block number of SpuriousDragon
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -65,6 +66,9 @@ fi
 if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 if [ "$chainconfig" != "{}" ]; then

--- a/clients/go-ethereum:master/geth.sh
+++ b/clients/go-ethereum:master/geth.sh
@@ -17,7 +17,8 @@
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
 #  - HIVE_FORK_TANGERINE block number of TangerineWhistle
-#  - HIVE_FORK_SPURIOUS  block number of SpurioisDragon
+#  - HIVE_FORK_SPURIOUS  block number of SpuriousDragon
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -65,6 +66,9 @@ fi
 if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 

--- a/clients/go-ethereum:stable/geth.sh
+++ b/clients/go-ethereum:stable/geth.sh
@@ -17,7 +17,8 @@
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
 #  - HIVE_FORK_TANGERINE block number of TangerineWhistle
-#  - HIVE_FORK_SPURIOUS  block number of SpurioisDragon
+#  - HIVE_FORK_SPURIOUS  block number of SpuriousDragon
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -65,6 +66,9 @@ fi
 if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 if [ "$chainconfig" != "{}" ]; then

--- a/clients/parity:beta/Dockerfile
+++ b/clients/parity:beta/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   apt-get install -y curl git make g++ gcc file binutils pkg-config openssl libssl-dev && \
   curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo && \
 	\
-  git clone --depth 1 --branch beta https://github.com/ethcore/parity && \
+  git clone --depth 1 --branch beta https://github.com/paritytech/parity && \
 	cd parity && cargo build --release                                  && \
 	strip /parity/target/release/parity                                 && \
 	\

--- a/clients/parity:beta/chain.json
+++ b/clients/parity:beta/chain.json
@@ -137,7 +137,10 @@
     "accountStartNonce": "0x0",
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
-    "networkID" : "0x0"
+    "networkID" : "0x0",
+    "eip98Transition": "0x7fffffffffffff",
+    "eip86Transition": "0x7fffffffffffff"
+
   },
   "nodes": [],
   "accounts": {

--- a/clients/parity:beta/parity.sh
+++ b/clients/parity:beta/parity.sh
@@ -16,6 +16,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -85,7 +86,11 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
-
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+fi
 
 echo $chainconfig > /chain.json
 FLAGS="$FLAGS --chain /chain.json"

--- a/clients/parity:master/Dockerfile
+++ b/clients/parity:master/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   curl -sSf https://static.rust-lang.org/rustup.sh         |  \
   sh -s -- --disable-sudo                                  && \
   \
-  git clone --depth 1 https://github.com/ethcore/parity && \
+  git clone --depth 1 https://github.com/paritytech/parity && \
 	cd parity && cargo build --release                    && \
 	strip /parity/target/release/parity                   && \
 	\

--- a/clients/parity:master/chain.json
+++ b/clients/parity:master/chain.json
@@ -137,7 +137,9 @@
     "accountStartNonce": "0x0",
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
-    "networkID" : "0x0"
+    "networkID" : "0x0",
+    "eip98Transition": "0x7fffffffffffff",
+    "eip86Transition": "0x7fffffffffffff"
   },
   "nodes": [],
   "accounts": {

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -16,6 +16,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -85,7 +86,11 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
-
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+fi
 
 echo $chainconfig > /chain.json
 FLAGS="$FLAGS --chain /chain.json"

--- a/clients/parity:stable/Dockerfile
+++ b/clients/parity:stable/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   curl -sSf https://static.rust-lang.org/rustup.sh         |  \
   sh -s -- --disable-sudo                                  && \
   \
-  git clone --depth 1 --branch stable https://github.com/ethcore/parity && \
+  git clone --depth 1 --branch stable https://github.com/paritytech/parity && \
 	cd parity && cargo build --release                                    && \
 	strip /parity/target/release/parity                                   && \
 	\

--- a/clients/parity:stable/chain.json
+++ b/clients/parity:stable/chain.json
@@ -17,7 +17,9 @@
     "accountStartNonce": "0x0",
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
-    "networkID" : "0x0"
+    "networkID" : "0x0",
+    "eip98Transition": "0x7fffffffffffff",
+    "eip86Transition": "0x7fffffffffffff"
   },
   "nodes": [],
   "accounts": {

--- a/clients/parity:stable/parity.sh
+++ b/clients/parity:stable/parity.sh
@@ -16,6 +16,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -53,12 +54,39 @@ if [ "$HIVE_TESTNET" == "1" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x789b0\")"`
 fi
 if [ "$HIVE_FORK_HOMESTEAD" != "" ]; then
-	HIVE_FORK_HOMESTEAD=`echo "obase=16; $HIVE_FORK_HOMESTEAD" | bc`
-	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x$HIVE_FORK_HOMESTEAD\")"`
+	HEX_HIVE_FORK_HOMESTEAD=`echo "obase=16; $HIVE_FORK_HOMESTEAD" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"homesteadTransition\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
+fi
+
+if [ "$HIVE_FORK_DAO_BLOCK" != "" ]; then
+	HIVE_FORK_DAO_BLOCK=`echo "obase=16; $HIVE_FORK_DAO_BLOCK" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"daoHardforkTransition\"]; \"0x$HIVE_FORK_DAO_BLOCK\")"`
+fi
+
+if [ "$HIVE_FORK_TANGERINE" != "" ]; then
+	HIVE_FORK_TANGERINE=`echo "obase=16; $HIVE_FORK_TANGERINE" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip150Transition\"]; \"0x$HIVE_FORK_TANGERINE\" )"`
+fi
+
+if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
+	HIVE_FORK_SPURIOUS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip155Transition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip160Transition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
 fi
 
 echo $chainconfig > /chain.json
 FLAGS="$FLAGS --chain /chain.json"
+
+# Don't immediately abort, some imports are meant to fail
+set +e
 
 # Load the test chain if present
 echo "Loading initial blockchain..."
@@ -73,6 +101,9 @@ if [ -d /blocks ]; then
 		/parity $FLAGS import /blocks/$block
 	done
 fi
+
+# Immediately abort the script on any error encountered
+set -e
 
 # Load any keys explicitly added to the node
 if [ -d /keys ]; then

--- a/simulators/ethereum/consensus/testmodel.py
+++ b/simulators/ethereum/consensus/testmodel.py
@@ -7,6 +7,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 2000,
         "HIVE_FORK_SPURIOUS"  : 2000,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
 
     RULES_HOMESTEAD = {
@@ -15,6 +16,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 2000,
         "HIVE_FORK_SPURIOUS"  : 2000,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
 
     RULES_TANGERINE = {
@@ -22,6 +24,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 0,
         "HIVE_FORK_SPURIOUS"  : 2000,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
     RULES_SPURIOUS = {
 
@@ -29,6 +32,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 0,
         "HIVE_FORK_SPURIOUS"  : 0,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
 
     RULES_TRANSITIONNET = {
@@ -36,6 +40,15 @@ class Rules():
         "HIVE_FORK_DAO_BLOCK" : 8,
         "HIVE_FORK_TANGERINE" : 10,
         "HIVE_FORK_SPURIOUS"  : 14,
+        "HIVE_FORK_METROPOLIS": 2000, 
+    }
+
+    RULES_METROPOLIS = {
+        "HIVE_FORK_HOMESTEAD" : 0,
+        "HIVE_FORK_TANGERINE" : 0,
+        "HIVE_FORK_SPURIOUS"  : 0,
+        "HIVE_FORK_DAO_BLOCK" : 0,
+        "HIVE_FORK_METROPOLIS": 0, 
     }
 # Model for the testcases
 class Testfile(object):
@@ -113,6 +126,7 @@ class Testcase(object):
             "EIP150"    : Rules.RULES_TANGERINE,
             "EIP158"    : Rules.RULES_SPURIOUS,
             "TransitionNet" : Rules.RULES_TRANSITIONNET,
+            "Metropolis" : Rules.RULES_METROPOLIS,
             }
 
 

--- a/simulators/ethereum/consensus/testmodel.py
+++ b/simulators/ethereum/consensus/testmodel.py
@@ -142,7 +142,7 @@ class Testcase(object):
 
             for key in fields_to_fix:
                 v = raw_genesis[key]
-                if not v[:2] == '0x':
+                if len(v) > 2 and v[:2] != '0x':
                     raw_genesis[key] = '0x'+raw_genesis[key]
 
             # And fix the alloc-section


### PR DESCRIPTION
Fixes in this PR

* Parity changed repo to 'paritytech', thus dockerfiles stopped working
* Geth's new (and grumpy) json-parsing, requires us to rewrite various fields in genesis
* Skips tests which contain invalid hex; specifically the "invalid rlp"-tests which cannot be converted into binary, thus impossible to execute. 
* Added config for Metropolis, both Geth and Parity (parity tests use Metro-rules unless this is included, so tests fail)
* Defined `Metropolis` network, which the ethereum tests use. 

