### PR TITLE
Metropolis, geth-fixes, parity-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ The behavioral configuration variables:
     * The HF for repricing certain opcodes, EIP 150
   * `HIVE_FORK_SPURIOUS` the block number of the Ethereum Homestead transition
     * The HF for replay protection, state cleaning etc. EIPs 155,160,161. 
+  * `HIVE_FORK_METROPOLIS` the block number of the Metropolis hardfork
   * `HIVE_MINER` address to credit with mining rewards (if set, start mining)
   * `HIVE_MINER_EXTRA` extra-data field to set for newly minted blocks
+
 
 ### Starting the client
 

--- a/clients/go-ethereum:local/geth.sh
+++ b/clients/go-ethereum:local/geth.sh
@@ -17,7 +17,8 @@
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
 #  - HIVE_FORK_TANGERINE block number of TangerineWhistle
-#  - HIVE_FORK_SPURIOUS  block number of SpurioisDragon
+#  - HIVE_FORK_SPURIOUS  block number of SpuriousDragon
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -65,6 +66,9 @@ fi
 if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 if [ "$chainconfig" != "{}" ]; then

--- a/clients/go-ethereum:local/geth.sh
+++ b/clients/go-ethereum:local/geth.sh
@@ -68,7 +68,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
 if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
-	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
+	chainconfig=`echo $chainconfig | jq ". + {\"metropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 if [ "$chainconfig" != "{}" ]; then

--- a/clients/go-ethereum:local/geth.sh
+++ b/clients/go-ethereum:local/geth.sh
@@ -67,7 +67,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
-if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 

--- a/clients/go-ethereum:master/geth.sh
+++ b/clients/go-ethereum:master/geth.sh
@@ -68,7 +68,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
 if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
-	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
+	chainconfig=`echo $chainconfig | jq ". + {\"metropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 

--- a/clients/go-ethereum:master/geth.sh
+++ b/clients/go-ethereum:master/geth.sh
@@ -17,7 +17,8 @@
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
 #  - HIVE_FORK_TANGERINE block number of TangerineWhistle
-#  - HIVE_FORK_SPURIOUS  block number of SpurioisDragon
+#  - HIVE_FORK_SPURIOUS  block number of SpuriousDragon
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -65,6 +66,9 @@ fi
 if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 

--- a/clients/go-ethereum:master/geth.sh
+++ b/clients/go-ethereum:master/geth.sh
@@ -67,7 +67,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
-if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 

--- a/clients/go-ethereum:metro/Dockerfile
+++ b/clients/go-ethereum:metro/Dockerfile
@@ -1,0 +1,27 @@
+# Docker container spec for building the master branch of go-ethereum.
+#
+# The build process it potentially longer running but every effort was made to
+# produce a very minimalistic container that can be reused many times without
+# needing to constantly rebuild.
+FROM alpine:latest
+
+
+# Build go-ethereum on the fly and delete all build tools afterwards
+RUN \
+  apk add --update bash jq go git make gcc musl-dev              \ 
+  	  ca-certificates linux-headers                           && \
+  git clone --depth 1 --branch metropolis-finalisation \
+  https://github.com/obscuren/go-ethereum.git && \
+  (cd go-ethereum && make geth)                               && \
+  cp go-ethereum/build/bin/geth /geth                         && \
+  apk del go git make gcc musl-dev linux-headers              && \
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+
+# Inject the startup script
+ADD geth.sh /geth.sh
+RUN chmod +x /geth.sh
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 30303
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum:metro/geth.sh
+++ b/clients/go-ethereum:metro/geth.sh
@@ -68,7 +68,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
 if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
-	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
+	chainconfig=`echo $chainconfig | jq ". + {\"metropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 if [ "$chainconfig" != "{}" ]; then

--- a/clients/go-ethereum:metro/geth.sh
+++ b/clients/go-ethereum:metro/geth.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Startup script to initialize and boot a go-ethereum instance.
+#
+# This script assumes the following files:
+#  - `geth` binary is located in the filesystem root
+#  - `genesis.json` file is located in the filesystem root (mandatory)
+#  - `chain.rlp` file is located in the filesystem root (optional)
+#  - `blocks` folder is located in the filesystem root (optional)
+#  - `keys` folder is located in the filesystem root (optional)
+#
+# This script assumes the following environment variables:
+#  - HIVE_BOOTNODE       enode URL of the remote bootstrap node
+#  - HIVE_TESTNET        whether testnet nonces (2^20) are needed
+#  - HIVE_NODETYPE       sync and pruning selector (archive, full, light)
+#  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
+#  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
+#  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_TANGERINE block number of TangerineWhistle
+#  - HIVE_FORK_SPURIOUS  block number of SpuriousDragon
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
+#  - HIVE_MINER          address to credit with mining rewards (single thread)
+#  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
+
+# Immediately abort the script on any error encountered
+set -e
+
+# It doesn't make sense to dial out, use only a pre-set bootnode
+if [ "$HIVE_BOOTNODE" != "" ]; then
+	FLAGS="$FLAGS --bootnodes $HIVE_BOOTNODE"
+else
+	FLAGS="$FLAGS --nodiscover"
+fi
+
+# If the client is to be run in testnet mode, flag it as such
+if [ "$HIVE_TESTNET" == "1" ]; then
+	FLAGS="$FLAGS --testnet"
+fi
+
+# Handle any client mode or operation requests
+if [ "$HIVE_NODETYPE" == "full" ]; then
+	FLAGS="$FLAGS --fast"
+fi
+if [ "$HIVE_NODETYPE" == "light" ]; then
+	FLAGS="$FLAGS --light"
+fi
+
+# Override any chain configs in the go-ethereum specific way
+chainconfig="{}"
+if [ "$HIVE_FORK_HOMESTEAD" != "" ]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"homesteadBlock\": $HIVE_FORK_HOMESTEAD}"`
+fi
+if [ "$HIVE_FORK_DAO_BLOCK" != "" ]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"daoForkBlock\": $HIVE_FORK_DAO_BLOCK}"`
+fi
+if [ "$HIVE_FORK_DAO_VOTE" == "0" ]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"daoForkSupport\": false}"`
+fi
+if [ "$HIVE_FORK_DAO_VOTE" == "1" ]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"daoForkSupport\": true}"`
+fi
+
+if [ "$HIVE_FORK_TANGERINE" != "" ]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"eip150Block\": $HIVE_FORK_TANGERINE}"`
+fi
+if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
+	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
+fi
+
+
+if [ "$chainconfig" != "{}" ]; then
+	genesis=`cat /genesis.json` && echo $genesis | jq ". + {\"config\": $chainconfig}" > /genesis.json
+fi
+
+# Initialize the local testchain with the genesis state
+echo "Initializing database with genesis state..."
+/geth $FLAGS init /genesis.json
+
+# Don't immediately abort, some imports are meant to fail
+set +e
+
+# Load the test chain if present
+echo "Loading initial blockchain..."
+if [ -f /chain.rlp ]; then
+	/geth $FLAGS import /chain.rlp
+fi
+
+# Load the remainder of the test chain
+echo "Loading remaining individual blocks..."
+if [ -d /blocks ]; then
+	(cd blocks && ../geth $FLAGS --nocompaction import `ls | sort -n`)
+fi
+
+set -e
+
+# Load any keys explicitly added to the node
+if [ -d /keys ]; then
+	FLAGS="$FLAGS --keystore /keys"
+fi
+
+# Configure any mining operation
+if [ "$HIVE_MINER" != "" ]; then
+	FLAGS="$FLAGS --mine --minerthreads 1 --etherbase $HIVE_MINER"
+fi
+if [ "$HIVE_MINER_EXTRA" != "" ]; then
+	FLAGS="$FLAGS --extradata $HIVE_MINER_EXTRA"
+fi
+
+# Run the go-ethereum implementation with the requested flags
+echo "Running go-ethereum..."
+/geth $FLAGS --nat=none --rpc --rpcaddr "0.0.0.0" --rpcapi "admin,debug,eth,miner,net,personal,shh,txpool,web3" --ws --wsaddr "0.0.0.0" --wsapi "admin,debug,eth,miner,net,personal,shh,txpool,web3" --wsorigins "*"

--- a/clients/go-ethereum:metro/geth.sh
+++ b/clients/go-ethereum:metro/geth.sh
@@ -67,10 +67,9 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
-if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
-
 
 if [ "$chainconfig" != "{}" ]; then
 	genesis=`cat /genesis.json` && echo $genesis | jq ". + {\"config\": $chainconfig}" > /genesis.json

--- a/clients/go-ethereum:stable/geth.sh
+++ b/clients/go-ethereum:stable/geth.sh
@@ -17,7 +17,8 @@
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
 #  - HIVE_FORK_TANGERINE block number of TangerineWhistle
-#  - HIVE_FORK_SPURIOUS  block number of SpurioisDragon
+#  - HIVE_FORK_SPURIOUS  block number of SpuriousDragon
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -65,6 +66,9 @@ fi
 if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 if [ "$chainconfig" != "{}" ]; then

--- a/clients/go-ethereum:stable/geth.sh
+++ b/clients/go-ethereum:stable/geth.sh
@@ -68,7 +68,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
 if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
-	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
+	chainconfig=`echo $chainconfig | jq ". + {\"metropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 
 if [ "$chainconfig" != "{}" ]; then

--- a/clients/go-ethereum:stable/geth.sh
+++ b/clients/go-ethereum:stable/geth.sh
@@ -67,7 +67,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"eip158Block\": $HIVE_FORK_SPURIOUS}"`
 	chainconfig=`echo $chainconfig | jq ". + {\"eip155Block\": $HIVE_FORK_SPURIOUS}"`
 fi
-if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq ". + {\"MetropolisBlock\": $HIVE_FORK_METROPOLIS}"`
 fi
 

--- a/clients/parity:beta/Dockerfile
+++ b/clients/parity:beta/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   apt-get install -y curl git make g++ gcc file binutils pkg-config openssl libssl-dev && \
   curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo && \
 	\
-  git clone --depth 1 --branch beta https://github.com/ethcore/parity && \
+  git clone --depth 1 --branch beta https://github.com/paritytech/parity && \
 	cd parity && cargo build --release                                  && \
 	strip /parity/target/release/parity                                 && \
 	\

--- a/clients/parity:beta/chain.json
+++ b/clients/parity:beta/chain.json
@@ -137,7 +137,10 @@
     "accountStartNonce": "0x0",
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
-    "networkID" : "0x0"
+    "networkID" : "0x0",
+    "eip98Transition": "0x7fffffffffffff",
+    "eip86Transition": "0x7fffffffffffff"
+
   },
   "nodes": [],
   "accounts": {

--- a/clients/parity:beta/parity.sh
+++ b/clients/parity:beta/parity.sh
@@ -86,7 +86,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
-if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`

--- a/clients/parity:beta/parity.sh
+++ b/clients/parity:beta/parity.sh
@@ -16,6 +16,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -85,7 +86,11 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
-
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+fi
 
 echo $chainconfig > /chain.json
 FLAGS="$FLAGS --chain /chain.json"

--- a/clients/parity:master/Dockerfile
+++ b/clients/parity:master/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   curl -sSf https://static.rust-lang.org/rustup.sh         |  \
   sh -s -- --disable-sudo                                  && \
   \
-  git clone --depth 1 https://github.com/ethcore/parity && \
+  git clone --depth 1 https://github.com/paritytech/parity && \
 	cd parity && cargo build --release                    && \
 	strip /parity/target/release/parity                   && \
 	\

--- a/clients/parity:master/chain.json
+++ b/clients/parity:master/chain.json
@@ -137,7 +137,9 @@
     "accountStartNonce": "0x0",
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
-    "networkID" : "0x0"
+    "networkID" : "0x0",
+    "eip98Transition": "0x7fffffffffffff",
+    "eip86Transition": "0x7fffffffffffff"
   },
   "nodes": [],
   "accounts": {

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -86,7 +86,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
-if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -16,6 +16,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -85,7 +86,11 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
-
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+fi
 
 echo $chainconfig > /chain.json
 FLAGS="$FLAGS --chain /chain.json"

--- a/clients/parity:stable/Dockerfile
+++ b/clients/parity:stable/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   curl -sSf https://static.rust-lang.org/rustup.sh         |  \
   sh -s -- --disable-sudo                                  && \
   \
-  git clone --depth 1 --branch stable https://github.com/ethcore/parity && \
+  git clone --depth 1 --branch stable https://github.com/paritytech/parity && \
 	cd parity && cargo build --release                                    && \
 	strip /parity/target/release/parity                                   && \
 	\

--- a/clients/parity:stable/chain.json
+++ b/clients/parity:stable/chain.json
@@ -17,7 +17,9 @@
     "accountStartNonce": "0x0",
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
-    "networkID" : "0x0"
+    "networkID" : "0x0",
+    "eip98Transition": "0x7fffffffffffff",
+    "eip86Transition": "0x7fffffffffffff"
   },
   "nodes": [],
   "accounts": {

--- a/clients/parity:stable/parity.sh
+++ b/clients/parity:stable/parity.sh
@@ -76,7 +76,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
-if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`

--- a/clients/parity:stable/parity.sh
+++ b/clients/parity:stable/parity.sh
@@ -16,6 +16,7 @@
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_METROPOLIS block number for Metropolis transition
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 
@@ -53,12 +54,39 @@ if [ "$HIVE_TESTNET" == "1" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x789b0\")"`
 fi
 if [ "$HIVE_FORK_HOMESTEAD" != "" ]; then
-	HIVE_FORK_HOMESTEAD=`echo "obase=16; $HIVE_FORK_HOMESTEAD" | bc`
-	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x$HIVE_FORK_HOMESTEAD\")"`
+	HEX_HIVE_FORK_HOMESTEAD=`echo "obase=16; $HIVE_FORK_HOMESTEAD" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"homesteadTransition\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"frontierCompatibilityModeLimit\"]; \"0x$HEX_HIVE_FORK_HOMESTEAD\")"`
+fi
+
+if [ "$HIVE_FORK_DAO_BLOCK" != "" ]; then
+	HIVE_FORK_DAO_BLOCK=`echo "obase=16; $HIVE_FORK_DAO_BLOCK" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"daoHardforkTransition\"]; \"0x$HIVE_FORK_DAO_BLOCK\")"`
+fi
+
+if [ "$HIVE_FORK_TANGERINE" != "" ]; then
+	HIVE_FORK_TANGERINE=`echo "obase=16; $HIVE_FORK_TANGERINE" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip150Transition\"]; \"0x$HIVE_FORK_TANGERINE\" )"`
+fi
+
+if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
+	HIVE_FORK_SPURIOUS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip155Transition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip160Transition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+fi
+if [ "$HIVE_FORK_METROPOLIS" != ""]; then
+	HIVE_FORK_METROPOLIS=`echo "obase=16; $HIVE_FORK_SPURIOUS" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip98Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
 fi
 
 echo $chainconfig > /chain.json
 FLAGS="$FLAGS --chain /chain.json"
+
+# Don't immediately abort, some imports are meant to fail
+set +e
 
 # Load the test chain if present
 echo "Loading initial blockchain..."
@@ -73,6 +101,9 @@ if [ -d /blocks ]; then
 		/parity $FLAGS import /blocks/$block
 	done
 fi
+
+# Immediately abort the script on any error encountered
+set -e
 
 # Load any keys explicitly added to the node
 if [ -d /keys ]; then

--- a/simulators/ethereum/consensus/testmodel.py
+++ b/simulators/ethereum/consensus/testmodel.py
@@ -7,6 +7,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 2000,
         "HIVE_FORK_SPURIOUS"  : 2000,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
 
     RULES_HOMESTEAD = {
@@ -15,6 +16,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 2000,
         "HIVE_FORK_SPURIOUS"  : 2000,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
 
     RULES_TANGERINE = {
@@ -22,6 +24,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 0,
         "HIVE_FORK_SPURIOUS"  : 2000,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
     RULES_SPURIOUS = {
 
@@ -29,6 +32,7 @@ class Rules():
         "HIVE_FORK_TANGERINE" : 0,
         "HIVE_FORK_SPURIOUS"  : 0,
         "HIVE_FORK_DAO_BLOCK" : 2000,
+        "HIVE_FORK_METROPOLIS": 2000, 
     }
 
     RULES_TRANSITIONNET = {
@@ -36,6 +40,15 @@ class Rules():
         "HIVE_FORK_DAO_BLOCK" : 8,
         "HIVE_FORK_TANGERINE" : 10,
         "HIVE_FORK_SPURIOUS"  : 14,
+        "HIVE_FORK_METROPOLIS": 2000, 
+    }
+
+    RULES_METROPOLIS = {
+        "HIVE_FORK_HOMESTEAD" : 0,
+        "HIVE_FORK_TANGERINE" : 0,
+        "HIVE_FORK_SPURIOUS"  : 0,
+        "HIVE_FORK_DAO_BLOCK" : 0,
+        "HIVE_FORK_METROPOLIS": 0, 
     }
 # Model for the testcases
 class Testfile(object):
@@ -113,6 +126,7 @@ class Testcase(object):
             "EIP150"    : Rules.RULES_TANGERINE,
             "EIP158"    : Rules.RULES_SPURIOUS,
             "TransitionNet" : Rules.RULES_TRANSITIONNET,
+            "Metropolis" : Rules.RULES_METROPOLIS,
             }
 
 

--- a/simulators/ethereum/consensus/testmodel.py
+++ b/simulators/ethereum/consensus/testmodel.py
@@ -142,7 +142,7 @@ class Testcase(object):
 
             for key in fields_to_fix:
                 v = raw_genesis[key]
-                if not v[:2] == '0x':
+                if len(v) > 2 and v[:2] != '0x':
                     raw_genesis[key] = '0x'+raw_genesis[key]
 
             # And fix the alloc-section


### PR DESCRIPTION
Fixes in this PR

* Parity changed repo to 'paritytech', thus dockerfiles stopped working
* Geth's new (and grumpy) json-parsing, requires us to rewrite various fields in genesis
* Skips tests which contain invalid hex; specifically the "invalid rlp"-tests which cannot be converted into binary, thus impossible to execute. 
* Added config for Metropolis, both Geth and Parity (parity tests use Metro-rules unless this is included, so tests fail)
* Defined `Metropolis` network, which the ethereum tests use. 
* Fixes a bash-error in the metropolis integration, and adds the metro-geth from @obscuren. 

Supersedes https://github.com/karalabe/hive/pull/41