### PR TITLE
simulators/consensus: do not crash if fails to kill a node

### DIFF
--- a/simulators/ethereum/consensus/simulator.py
+++ b/simulators/ethereum/consensus/simulator.py
@@ -59,8 +59,8 @@ class HiveTestAPI(hivemodel.HiveAPI):
 
 def test():
     hive = HiveTestAPI()
-    executor = hivemodel.BlockTestExecutor(hive , Rules.RULES_TANGERINE)
-    hive.blockTests(testfiles= utils.getFiles("./tests/BlockchainTests"), executor = executor)
+    executor = hivemodel.BlockTestExecutor(Rules.RULES_TANGERINE)
+    hive.blockTests(testfiles=utils.getFiles("./tests/BlockchainTests"), executor=executor)
 
 def main(args):
 
@@ -74,21 +74,20 @@ def main(args):
     print("Hive simulator: %s\n" % hivesim)
     hive = hivemodel.HiveAPI(hivesim)
 
-    status = hive.blockTests(testfiles = utils.getFiles("./tests/BlockchainTests"), 
-        executor = hivemodel.BlockTestExecutor(hive , Rules.RULES_FRONTIER))
-#        start=0, end=2)
+    status = hive.blockTests(testfiles=utils.getFiles("./tests/BlockchainTests"),
+        executor=hivemodel.BlockTestExecutor(Rules.RULES_FRONTIER))
 
-    status = hive.blockTests(testfiles = utils.getFiles("./tests/BlockchainTests/EIP150"),
-        executor = hivemodel.BlockTestExecutor(hive , Rules.RULES_TANGERINE))
+    status = hive.blockTests(testfiles=utils.getFiles("./tests/BlockchainTests/EIP150"),
+        executor=hivemodel.BlockTestExecutor(Rules.RULES_TANGERINE))
 
-    status = hive.blockTests(testfiles = utils.getFiles("./tests/BlockchainTests/Homestead"),
-            executor = hivemodel.BlockTestExecutor(hive , Rules.RULES_HOMESTEAD))
+    status = hive.blockTests(testfiles=utils.getFiles("./tests/BlockchainTests/Homestead"),
+        executor=hivemodel.BlockTestExecutor(Rules.RULES_HOMESTEAD))
 
-    status = hive.blockTests(testfiles = utils.getFiles("./tests/BlockchainTests/TestNetwork"),
-            executor = hivemodel.BlockTestExecutor(hive , Rules.RULES_TRANSITIONNET))
-    
-    status = hive.blockTests(testfiles = utils.getFilesRecursive("./tests/BlockchainTests/GeneralStateTests/"), 
-        executor = hivemodel.BlockTestExecutor(hive))
+    status = hive.blockTests(testfiles=utils.getFiles("./tests/BlockchainTests/TestNetwork"),
+        executor=hivemodel.BlockTestExecutor(Rules.RULES_TRANSITIONNET))
+
+    status = hive.blockTests(testfiles=utils.getFilesRecursive("./tests/BlockchainTests/GeneralStateTests/"), 
+        executor=hivemodel.BlockTestExecutor())
 #        whitelist=["mload32bitBound_return2_d0g0v0_EIP150"])
 
     if not status:
@@ -98,4 +97,3 @@ def main(args):
 
 if __name__ == '__main__':
     main(sys.argv[1:])
-    

--- a/simulators/ethereum/consensus/testmodel.py
+++ b/simulators/ethereum/consensus/testmodel.py
@@ -236,7 +236,6 @@ class Testcase(object):
         self._skipped = True
         self.addMessage(message)
 
-
     def wasSuccessfull(self):
         return bool(self._success)
 


### PR DESCRIPTION
The killNode() method was not wrapped in a try/except, so if it raised
any exception it'd cause the whole simulator to crash.

Also refactors some code in hivemodel.py to make it simpler and easier
to follow.