### PR TITLE
Remove hardcoded folders, as tests now are configured with network

### DIFF
--- a/simulators/ethereum/consensus/hivemodel.py
+++ b/simulators/ethereum/consensus/hivemodel.py
@@ -105,8 +105,6 @@ class HiveAPI(object):
         if details is not None:
             data = {"details" : json.dumps(details) }
 
-#        print("Sending the following data with request: %s" % data)
-
         return self._post("/subresults", params = params, data = data);
 
     def newNode(self, params):
@@ -158,10 +156,10 @@ class BlockTestExecutor(object):
                     testcase.skipped(["Testcase in blacklist"])
                     continue
 
-                (ok, err) = testcase.validate()
+                err = testcase.validate()
 
-                if not ok:
-                    self.hive.log("%s failed initial validation" % testcase )
+                if err is not None:
+                    self.hive.log("%s / %s failed initial validation" % (tf, testcase) )
                     testcase.fail(["Testcase failed initial validation", err])
                 else:
                     yield testcase

--- a/simulators/ethereum/consensus/simulator.py
+++ b/simulators/ethereum/consensus/simulator.py
@@ -76,29 +76,15 @@ def main(args):
 
     status = hivemodel.BlockTestExecutor(
         hive_api=hive,
-        testfiles=utils.getFiles("./tests/BlockchainTests"),
-        rules=Rules.RULES_FRONTIER).run()
-
-    status = hivemodel.BlockTestExecutor(
-        hive_api=hive,
-        testfiles=utils.getFiles("./tests/BlockchainTests/EIP150"),
-        rules=Rules.RULES_TANGERINE).run()
-
-    status = hivemodel.BlockTestExecutor(
-        hive_api=hive,
-        testfiles=utils.getFiles("./tests/BlockchainTests/Homestead"),
-        rules=Rules.RULES_HOMESTEAD).run()
-
-    status = hivemodel.BlockTestExecutor(
-        hive_api=hive,
-        testfiles=utils.getFiles("./tests/BlockchainTests/TestNetwork"),
-        rules=Rules.RULES_TRANSITIONNET).run()
-
-    status = hivemodel.BlockTestExecutor(
-        hive_api=hive,
-        testfiles=utils.getFilesRecursive("./tests/BlockchainTests/GeneralStateTests/"),
+        testfiles=utils.getFilesRecursive("./tests/BlockchainTests/"),
         rules=None).run()
 
+
+#    status = hivemodel.BlockTestExecutor(
+#        hive_api=hive,
+#        testfiles=utils.getFilesRecursive("./tests/BlockchainTests/GeneralStateTests/"),
+#        rules=None).run()
+#
     if not status:
         sys.exit(-1)
 

--- a/simulators/ethereum/consensus/testmodel.py
+++ b/simulators/ethereum/consensus/testmodel.py
@@ -87,7 +87,7 @@ class Testcase(object):
         self._message = []
         self.nodeInstance = "N/A"
         self.clientType = "N/A"
-        self.required_keys = ["pre","blocks","postState","genesisBlockHeader"]
+        self.required_keys = ["pre","blocks","postState","genesisBlockHeader","network"]
 
     def __str__(self):
         return self.name
@@ -110,7 +110,10 @@ class Testcase(object):
                 missing_keys.append(k)
 
 
-        return (len(missing_keys) == 0 ,"Missing keys: %s" % (",".join(missing_keys)))
+        if len(missing_keys) > 0:
+            return "Missing keys: %s" % (",".join(missing_keys))
+
+        return None
 
     def ruleset(self, default=Rules.RULES_FRONTIER):
         """In some cases (newer tests), the ruleset is specified in the
@@ -225,7 +228,7 @@ class Testcase(object):
         self.addMessage(message)
 
         self._skipped = False
-        print("%s failed : %s " %(self, str(self._message)))
+        print("%s %s failed : %s " %(self.testfile, self, str(self._message)))
 
     def success(self, message = []):
         self._success = True


### PR DESCRIPTION
The tests have now been changed, to not use hardcoded folders but instead that each test has a `network` configuration. This means that we don't have to infer rules from the folder, but can scan the test repo for tests in all folders recursively. 