### PR TITLE
skip constantinople tests in consensus runner

### DIFF
--- a/simulators/ethereum/consensus/hivemodel.py
+++ b/simulators/ethereum/consensus/hivemodel.py
@@ -156,6 +156,10 @@ class BlockTestExecutor(object):
                     testcase.skipped(["Testcase in blacklist"])
                     continue
 
+                if testcase.get('network') == 'Constantinople':
+                    testcase.skipped(["Testcase for Constantinople skipped"])
+                    continue
+
                 err = testcase.validate()
 
                 if err is not None:


### PR DESCRIPTION
## Warning: PR still untested

Skip Constantinople cases since they are guaranteed to show up as failures on [hivetests](http://hivetests.ethstats.net/) for clients that are only targeting Byzantium.