### PR TITLE
fix typo for cpp homestead config

### DIFF
--- a/clients/cpp-ethereum:develop/config.json
+++ b/clients/cpp-ethereum:develop/config.json
@@ -2,7 +2,7 @@
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x118c30",
+		"homesteadForkBlock": "0x118c30",
 		"daoHardforkBlock": "0x1d4c00",
 		"EIP150ForkBlock": "0x259518",
 		"EIP158ForkBlock": "0x28d138",


### PR DESCRIPTION
typo fixed in https://github.com/ethereum/cpp-ethereum/pull/4434