### PR TITLE
Use one block-rlp file instead of several (experiment)

### DIFF
--- a/simulators/ethereum/consensus/hivemodel.py
+++ b/simulators/ethereum/consensus/hivemodel.py
@@ -246,18 +246,33 @@ class BlockTestExecutor(object):
             with open(g_file,"w+") as g:
                 json.dump(testcase.genesis(),g)
 
+#        if testcase.blocks() is not None:
+#            counter = 1
+#            try:
+#                for block in testcase.blocks():
+#                    b_file = "./artefacts/%s/blocks/%04d.rlp" % (testcase, counter)
+#                    binary_string = binascii.unhexlify(block['rlp'][2:])
+#                    with open(b_file,"wb+") as outf:
+#                        outf.write(binary_string)
+#                    counter = counter +1
+#            except TypeError, e:
+#                #Bad rlp
+#                self.hive.log("Exception: %s, continuing regardless" % e)
+
+        # Try writing all blocks into one file
         if testcase.blocks() is not None:
             counter = 1
-            try:
-                for block in testcase.blocks():
-                    b_file = "./artefacts/%s/blocks/%04d.rlp" % (testcase, counter)
-                    binary_string = binascii.unhexlify(block['rlp'][2:])
-                    with open(b_file,"wb+") as outf:
-                        outf.write(binary_string)
-                    counter = counter +1
-            except TypeError, e:
-                #Bad rlp
-                self.hive.log("Exception: %s, continuing regardless" % e)
+            blocksrlp = []
+            for block in testcase.blocks():
+                try:
+                    blocksrlp.append(binascii.unhexlify(block['rlp'][2:]))
+                except TypeError, e:
+                    #Bad rlp
+                    self.hive.log("Exception: %s, continuing regardless" % e)
+
+            b_file = "./artefacts/%s/blocks/%04d.rlp" % (testcase, counter)
+            with open(b_file,"wb+") as outf:
+                outf.write("".join(blocksrlp))
 
         return (g_file, c_file, b_folder)
 


### PR DESCRIPTION
Don't merge this PR, it's probably not a good one. 

Results from doing it this way. 
Geth: 
This PR: `2h0m55s` (`147` failures)
Master:  `2h0m38s` (`20` failures)

Parity:
This PR: `2h55m49s` (`34` failures)
Master: `3h42m8s` (`0` failures)

Reson for geth-failures - it expects blocks in one single import to be contiguous: 
```
INFO [10-17|12:38:03] Importing blockchain                     file=0001.rlp
ERROR[10-17|12:38:03] Non contiguous block insert              number=1 hash=3f0957…c5fa46 parent=7285ab…2a46f7 prevnumber=5 prevhash=ccdb52…cc70b4
Fatal: Import error: invalid block 10: non contiguous insert: item 4 is #5 [ccdb52a8…], item 5 is #1 [3f0957de…] (parent [7285abd5…])
```
Reason for parity fail: 
```
2017-10-17 16:12:05 UTC Configured for Hive using Ethash engine
Cannot import block: Block(UnknownParent(0000000000000000000000000000000000000000000000000000000000000000))
```