### PR TITLE
Fixed ethereumj:develop client to be fully built in Dockerfile

### DIFF
--- a/clients/ethereumj:develop/Dockerfile
+++ b/clients/ethereumj:develop/Dockerfile
@@ -76,18 +76,17 @@ echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.c
 # Build Harmony on the fly and delete all build tools afterwards
 RUN \
   apk add --update git jq                                                 && \
-  git clone -b develop https://github.com/ether-camp/ethereum-harmony.git && \
-  git clone -b develop https://github.com/ethereum/ethereumj.git          && \
-  (cd ethereum-harmony                                                    && \
+  git clone --depth 1 -b develop https://github.com/ether-camp/ethereum-harmony.git && \
+  git clone --depth 1 -b develop https://github.com/ethereum/ethereumj.git          && \
+  (cd ethereum-harmony && git checkout develop  && git pull               && \
   echo "{}"                                                                  \
   | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}"             \
   | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"              \
   | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"                           \
 	> /version.json)                                                      && \
-  cd /ethereumj && git checkout develop                                   && \
-  cd /ethereumj && git pull                                               && \
-  cd /ethereumj && ./gradlew install -x test                              && \
-  cd /ethereum-harmony && git pull	                                      && \
+  (cd /ethereumj && git checkout develop && git pull)                     && \
+  (cd /ethereumj && ./gradlew install -x test)                            && \
+  (cd /ethereum-harmony && ./gradlew dependencyManagement jar -x test -PuseMavenLocal) && \
   apk del git
 
 

--- a/clients/ethereumj:master/harmony.sh
+++ b/clients/ethereumj:master/harmony.sh
@@ -32,7 +32,7 @@ fi
 
 # If the client is to be run in testnet mode, flag it as such
 if [ "$HIVE_TESTNET" == "1" ]; then
-	FLAGS="$FLAGS -Dblockchain.config.name=morden"
+	FLAGS="$FLAGS -Dblockchain.config.name=ropsten"
 fi
 
 # Handle any client mode or operation requests
@@ -73,10 +73,19 @@ fi
 # Initialize the local testchain with the genesis state
 echo "Initializing database with genesis state..."
 FLAGS="$FLAGS -DgenesisFile=/genesis.json"
+FLAGS="$FLAGS -Dethash.dir=/root/.ethash"
 
 FLAGS="$FLAGS -Dserver.port=8545"
 FLAGS="$FLAGS -Ddatabase.dir=database"
 FLAGS="$FLAGS -Dlogs.keepStdOut=true"
+
+FLAGS="$FLAGS -Dlogging.level.sync=ERROR"
+FLAGS="$FLAGS -Dlogging.level.net=INFO"
+FLAGS="$FLAGS -Dlogging.level.discover=ERROR"
+FLAGS="$FLAGS -Dlogging.level.general=ERROR"
+FLAGS="$FLAGS -Dlogging.level.mine=ERROR"
+FLAGS="$FLAGS -Dlogging.level.jsonrpc=ERROR"
+FLAGS="$FLAGS -Dlogging.level.harmony=ERROR"
 
 # Load the test chain if present
 echo "Loading initial blockchain..."
@@ -100,12 +109,12 @@ fi
 
 # Load any keys explicitly added to the node
 if [ -d /keys ]; then
-	FLAGS="$FLAGS -Dkeystore.dir=/keys"
+    FLAGS="$FLAGS -Dkeystore.dir=/keys"
 fi
 
 # Configure any mining operation
 if [ "$HIVE_MINER" != "" ]; then
-	# We don't start mining here, but only set mining options
+    # We don't start mining here, but only set mining options
 	FLAGS="$FLAGS -Dmine.coinbase=$HIVE_MINER -Dmine.cpuMineThreads=1"
 
 	if [ "$HIVE_MINER_NO_AUTO_MINE" != "1" ]; then


### PR DESCRIPTION
ethereumj:develop was not fully built on built stage in Dockerfile, so it downloaded dependencies on every test. I've fixed it. Should resolve #88 