### PR TITLE
Fix for https://github.com/paritytech/parity/pull/8067

### DIFF
--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -91,6 +91,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip160Transition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"maxCodeSizeTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
 if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	# Based on 


### PR DESCRIPTION
Fixes error caused when parity moved the `maxCodeSizeTransition` as a parameter into the chain config in https://github.com/paritytech/parity/pull/8067 . 