### PR TITLE
set parity fork numbers to very high (otherwise defaults to 0)

### DIFF
--- a/clients/parity:master/chain.json
+++ b/clients/parity:master/chain.json
@@ -141,6 +141,12 @@
     "networkID" : "0x0",
     "eip98Transition": "0x7fffffffffffff",
     "eip86Transition": "0x7fffffffffffff"
+    "eip155Transition": "0x7fffffffffffffff",
+    "eip150Transition": "0x7fffffffffffffff",
+    "eip160Transition": "0x7fffffffffffffff",
+    "eip161abcTransition": "0x7fffffffffffffff",
+    "eip161dTransition": "0x7fffffffffffffff"
+
   },
   "nodes": [],
   "accounts": {

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -91,7 +91,7 @@ if [ "$HIVE_FORK_SPURIOUS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip160Transition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip161abcTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip161dTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
-	chainconfig=`echo $chainconfig | jq "setpath([\"engine\", \"Ethash\", \"params\", \"maxCodeSizeTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"maxCodeSizeTransition\"]; \"0x$HIVE_FORK_SPURIOUS\")"`
 fi
 if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	# Based on 


### PR DESCRIPTION
Parity needs to have defaults for fork numbers, otherwise it becomes `0`. 