### PR TITLE
Add constantinople configs

### DIFF
--- a/clients/aleth:nightly/aleth.sh
+++ b/clients/aleth:nightly/aleth.sh
@@ -93,6 +93,10 @@ if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([ \"params\", \"byzantiumForkBlock\"]; \"0x$HIVE_FORK_METROPOLIS\")"`
 fi
 
+if [ "$HIVE_FORK_CONSTANTINOPLE" != "" ]; then
+	HIVE_FORK_CONSTANTINOPLE=`echo "obase=16; $HIVE_FORK_CONSTANTINOPLE" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([ \"params\", \"constantinopleForkBlock\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
+fi
 
 if [ "$accounts" != "" ]; then
 	# In some cases, the 'alloc' portion can be extremely large.

--- a/clients/parity:beta/parity.sh
+++ b/clients/parity:beta/parity.sh
@@ -126,6 +126,8 @@ if [ "$HIVE_FORK_CONSTANTINOPLE" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1052Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
 	# EIP 1283, net gas metering version 2
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1283Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
+	# Skinny create 2 (overloaded on eip86 for some reason)
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
 
 fi
 echo $chainconfig > /chain.json

--- a/clients/parity:beta/parity.sh
+++ b/clients/parity:beta/parity.sh
@@ -119,7 +119,15 @@ if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"accounts\", \"0000000000000000000000000000000000000007\", \"builtin\"]; { \"name\": \"alt_bn128_mul\", \"activate_at\": \"0x$HIVE_FORK_METROPOLIS\", \"pricing\": { \"linear\": { \"base\": 40000, \"word\": 0 } } })"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"accounts\", \"0000000000000000000000000000000000000008\", \"builtin\"]; { \"name\": \"alt_bn128_pairing\", \"activate_at\": \"0x$HIVE_FORK_METROPOLIS\", \"pricing\": { \"alt_bn128_pairing\": { \"base\": 100000, \"pair\": 80000 } } })"`
 fi
+if [ "$HIVE_FORK_CONSTANTINOPLE" != "" ]; then
+	# New shift instructions
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip145Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
+	# EXTCODEHASH
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1052Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
+	# EIP 1283, net gas metering version 2
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1283Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
 
+fi
 echo $chainconfig > /chain.json
 echo "Chain config: "
 cat /chain.json

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -126,6 +126,8 @@ if [ "$HIVE_FORK_CONSTANTINOPLE" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1052Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
 	# EIP 1283, net gas metering version 2
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1283Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
+	# Skinny create 2 (overloaded on eip86 for some reason)
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip86Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
 
 fi
 echo $chainconfig > /chain.json

--- a/clients/parity:master/parity.sh
+++ b/clients/parity:master/parity.sh
@@ -119,7 +119,15 @@ if [ "$HIVE_FORK_METROPOLIS" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"accounts\", \"0000000000000000000000000000000000000007\", \"builtin\"]; { \"name\": \"alt_bn128_mul\", \"activate_at\": \"0x$HIVE_FORK_METROPOLIS\", \"pricing\": { \"linear\": { \"base\": 40000, \"word\": 0 } } })"`
 	chainconfig=`echo $chainconfig | jq "setpath([\"accounts\", \"0000000000000000000000000000000000000008\", \"builtin\"]; { \"name\": \"alt_bn128_pairing\", \"activate_at\": \"0x$HIVE_FORK_METROPOLIS\", \"pricing\": { \"alt_bn128_pairing\": { \"base\": 100000, \"pair\": 80000 } } })"`
 fi
+if [ "$HIVE_FORK_CONSTANTINOPLE" != "" ]; then
+	# New shift instructions
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip145Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
+	# EXTCODEHASH
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1052Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
+	# EIP 1283, net gas metering version 2
+	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"eip1283Transition\"]; \"0x$HIVE_FORK_CONSTANTINOPLE\")"`
 
+fi
 echo $chainconfig > /chain.json
 echo "Chain config: "
 cat /chain.json


### PR DESCRIPTION
As per https://github.com/karalabe/hive/issues/113
This PR so far adds
- [x] Parity
  - [x] Shift operations
  - [x] net gas metering
  - [x] extcodehash
  - [x] Skinny create2 

- [x] Aleth


@chfast, could you help out with the aleth configs? 
@folsen, could you help out with what to use for skinny create 2 ? 

