### PR TITLE
Fixing Issue 111: Add json output of build error

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -89,15 +89,14 @@ func mainInHost(daemon *docker.Client, overrides []string, cacher *buildCacher) 
 		b, ok := err.(*buildError)
 		if ok {
 			results.Clients = make(map[string]map[string]string)
-			results.Clients[b.Client()] = make(map[string]string)
-			results.Clients[b.Client()] = map[string]string{"Failure": "Error building docker container for client"}
+			results.Clients[b.Client()] = map[string]string{"error": b.Error()}
+			out, errMarshal := json.MarshalIndent(results, "", "  ")
+			if errMarshal != nil {
+				log15.Crit("failed to report results. Docker Failed build.", "error", err)
+				return err
+			}
+			fmt.Println(string(out))
 		}
-		out, errMarshal := json.MarshalIndent(results, "", "  ")
-		if errMarshal != nil {
-			log15.Crit("failed to report results. Docker Failed build.", "error", err)
-			return err
-		}
-		fmt.Println(string(out))
 		return err
 	}
 	// Smoke tests are exclusive with all other flags

--- a/hive.go
+++ b/hive.go
@@ -86,6 +86,18 @@ func mainInHost(daemon *docker.Client, overrides []string, cacher *buildCacher) 
 	// Retrieve the versions of all clients being tested
 	if results.Clients, err = fetchClientVersions(daemon, *clientPattern, cacher); err != nil {
 		log15.Crit("failed to retrieve client versions", "error", err)
+		b, ok := err.(*buildError)
+		if ok {
+			results.Clients = make(map[string]map[string]string)
+			results.Clients[b.Client()] = make(map[string]string)
+			results.Clients[b.Client()] = map[string]string{"Failure": "Error building docker container for client"}
+		}
+		out, errMarshal := json.MarshalIndent(results, "", "  ")
+		if errMarshal != nil {
+			log15.Crit("failed to report results. Docker Failed build.", "error", err)
+			return err
+		}
+		fmt.Println(string(out))
 		return err
 	}
 	// Smoke tests are exclusive with all other flags

--- a/images.go
+++ b/images.go
@@ -81,11 +81,13 @@ func fetchClientVersions(daemon *docker.Client, pattern string, cacher *buildCac
 
 		blob, err := downloadFromImage(daemon, image, "/version.json", logger)
 		if err != nil {
-			return nil, err
+			berr := &buildError{err: err, client: image}
+			return nil, berr
 		}
 		var version map[string]string
 		if err := json.Unmarshal(blob, &version); err != nil {
-			return nil, err
+			berr := &buildError{err: err, client: image}
+			return nil, berr
 		}
 		versions[client] = version
 	}
@@ -154,7 +156,7 @@ func buildNestedImages(daemon *docker.Client, root string, pattern string, kind 
 }
 
 type buildError struct {
-	err error
+	err    error
 	client string
 }
 

--- a/images.go
+++ b/images.go
@@ -145,11 +145,25 @@ func buildNestedImages(daemon *docker.Client, root string, pattern string, kind 
 			logger  = log15.New(kind, name)
 		)
 		if err := buildImage(daemon, image, context, cacher, logger); err != nil {
-			return nil, fmt.Errorf("%s: %v", context, err)
+			berr := &buildError{err: fmt.Errorf("%s: %v", context, err), client: name}
+			return nil, berr
 		}
 		images[name] = image
 	}
 	return images, nil
+}
+
+type buildError struct {
+	err error
+	client string
+}
+
+func (b *buildError) Error() string {
+	return b.err.Error()
+}
+
+func (b *buildError) Client() string {
+	return b.client
 }
 
 // buildImage builds a single docker image from the specified context.

--- a/images.go
+++ b/images.go
@@ -81,12 +81,12 @@ func fetchClientVersions(daemon *docker.Client, pattern string, cacher *buildCac
 
 		blob, err := downloadFromImage(daemon, image, "/version.json", logger)
 		if err != nil {
-			berr := &buildError{err: err, client: image}
+			berr := &buildError{err: err, client: client}
 			return nil, berr
 		}
 		var version map[string]string
 		if err := json.Unmarshal(blob, &version); err != nil {
-			berr := &buildError{err: err, client: image}
+			berr := &buildError{err: err, client: client}
 			return nil, berr
 		}
 		versions[client] = version


### PR DESCRIPTION
Correcting issue 111 (https://github.com/karalabe/hive/issues/111). Issue corrected by creating buildError type to pass client information back to calling function. This type is then used to construct the json output as requested.